### PR TITLE
feat(wasi): add Preview1 output sinks

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,19 @@ Future<void> main() async {
 Uint8List loadWasiModuleBytes() => throw UnimplementedError();
 ```
 
+To capture guest output instead of forwarding it to the host process streams,
+provide per-instance byte sinks. Sinks receive raw bytes synchronously, so the
+host chooses whether to buffer, stream, or limit the output.
+
+```dart
+import 'dart:typed_data';
+import 'package:wasd/wasd.dart';
+
+final stdout = BytesBuilder();
+final stderr = BytesBuilder();
+final wasi = WASI(stdoutSink: stdout.add, stderrSink: stderr.add);
+```
+
 ## Module Metadata
 
 ```dart

--- a/lib/src/wasi/preview1/js/wasi.dart
+++ b/lib/src/wasi/preview1/js/wasi.dart
@@ -19,6 +19,8 @@ class WASI implements wasi_iface.WASI {
     int stdout = 1,
     int stderr = 2,
     Map<int, WASIPreview1Socket> sockets = const <int, WASIPreview1Socket>{},
+    wasi_iface.WASIOutputSink? stdoutSink,
+    wasi_iface.WASIOutputSink? stderrSink,
     wasi_iface.WASIProcRaiseHandler? procRaiseHandler,
     wasi_iface.WASIVersion version = wasi_iface.WASIVersion.preview1,
   }) : _delegate = _createDelegate(
@@ -32,6 +34,8 @@ class WASI implements wasi_iface.WASI {
          stdout: stdout,
          stderr: stderr,
          sockets: sockets,
+         stdoutSink: stdoutSink,
+         stderrSink: stderrSink,
          procRaiseHandler: procRaiseHandler,
          version: version,
        );
@@ -66,6 +70,8 @@ wasi_iface.WASI _createDelegate({
   required int stdout,
   required int stderr,
   required Map<int, WASIPreview1Socket> sockets,
+  required wasi_iface.WASIOutputSink? stdoutSink,
+  required wasi_iface.WASIOutputSink? stderrSink,
   required wasi_iface.WASIProcRaiseHandler? procRaiseHandler,
   required wasi_iface.WASIVersion version,
 }) {
@@ -83,6 +89,8 @@ wasi_iface.WASI _createDelegate({
     stdout: stdout,
     stderr: stderr,
     sockets: sockets,
+    stdoutSink: stdoutSink,
+    stderrSink: stderrSink,
     procRaiseHandler: procRaiseHandler,
     version: version,
   );

--- a/lib/src/wasi/preview1/js/web/wasi.dart
+++ b/lib/src/wasi/preview1/js/web/wasi.dart
@@ -30,10 +30,14 @@ class WASI implements wasi.WASI {
     int stdout = 1,
     int stderr = 2,
     Map<int, WASIPreview1Socket> sockets = const <int, WASIPreview1Socket>{},
+    wasi.WASIOutputSink? stdoutSink,
+    wasi.WASIOutputSink? stderrSink,
     wasi.WASIProcRaiseHandler? procRaiseHandler,
     wasi.WASIVersion version = wasi.WASIVersion.preview1,
   }) : _returnOnExit = returnOnExit,
        _procRaiseHandler = procRaiseHandler,
+       _stdoutSink = stdoutSink,
+       _stderrSink = stderrSink,
        _argsData = [for (final arg in args) wasi_vfs.nulTerminated(arg)],
        _envData = [
          for (final entry in env.entries)
@@ -54,6 +58,8 @@ class WASI implements wasi.WASI {
 
   final bool _returnOnExit;
   final wasi.WASIProcRaiseHandler? _procRaiseHandler;
+  final wasi.WASIOutputSink? _stdoutSink;
+  final wasi.WASIOutputSink? _stderrSink;
   final List<Uint8List> _argsData;
   final List<Uint8List> _envData;
   final Map<String, String> _nodeHostPreopensByGuestPath;
@@ -235,12 +241,26 @@ class WASI implements wasi.WASI {
         }
 
         if (totalBytes > 0) {
-          _writeJsStdio(stdioKind!, output.takeBytes());
+          _writeStdio(stdioKind!, Uint8List.fromList(output.takeBytes()));
         }
 
         data.setUint32(nwrittenPtr, totalBytes, Endian.little);
         return _errnoSuccess;
       });
+
+  void _writeStdio(
+    wasi_vfs.Preview1StdioDescriptorKind stdioKind,
+    Uint8List output,
+  ) {
+    final sink = stdioKind == wasi_vfs.Preview1StdioDescriptorKind.stdout
+        ? _stdoutSink
+        : _stderrSink;
+    if (sink != null) {
+      sink(output);
+      return;
+    }
+    _writeJsStdio(stdioKind, output);
+  }
 
   wasm.FunctionImportExportValue
   get _argsSizesGetImport => wasm.ImportExportKind.function((

--- a/lib/src/wasi/preview1/native/wasi.dart
+++ b/lib/src/wasi/preview1/native/wasi.dart
@@ -29,10 +29,14 @@ class WASI implements wasi_iface.WASI {
     int stdout = 1,
     int stderr = 2,
     Map<int, WASIPreview1Socket> sockets = const <int, WASIPreview1Socket>{},
+    wasi_iface.WASIOutputSink? stdoutSink,
+    wasi_iface.WASIOutputSink? stderrSink,
     wasi_iface.WASIProcRaiseHandler? procRaiseHandler,
     wasi_iface.WASIVersion version = wasi_iface.WASIVersion.preview1,
   }) : _returnOnExit = returnOnExit,
        _procRaiseHandler = procRaiseHandler,
+       _stdoutSink = stdoutSink,
+       _stderrSink = stderrSink,
        _argsData = [for (final arg in args) wasi_vfs.nulTerminated(arg)],
        _envData = [
          for (final entry in env.entries)
@@ -53,6 +57,8 @@ class WASI implements wasi_iface.WASI {
 
   final bool _returnOnExit;
   final wasi_iface.WASIProcRaiseHandler? _procRaiseHandler;
+  final wasi_iface.WASIOutputSink? _stdoutSink;
+  final wasi_iface.WASIOutputSink? _stderrSink;
   final List<Uint8List> _argsData;
   final List<Uint8List> _envData;
   final Map<String, String> _hostPreopensByGuestPath;
@@ -235,16 +241,30 @@ class WASI implements wasi_iface.WASI {
         }
 
         if (output.isNotEmpty) {
-          if (stdioKind == wasi_vfs.Preview1StdioDescriptorKind.stdout) {
-            io.stdout.add(output);
-          } else {
-            io.stderr.add(output);
-          }
+          _writeStdio(stdioKind!, Uint8List.fromList(output));
         }
 
         data.setUint32(nwrittenPtr, totalBytes, Endian.little);
         return _errnoSuccess;
       });
+
+  void _writeStdio(
+    wasi_vfs.Preview1StdioDescriptorKind stdioKind,
+    Uint8List output,
+  ) {
+    final sink = stdioKind == wasi_vfs.Preview1StdioDescriptorKind.stdout
+        ? _stdoutSink
+        : _stderrSink;
+    if (sink != null) {
+      sink(output);
+      return;
+    }
+    if (stdioKind == wasi_vfs.Preview1StdioDescriptorKind.stdout) {
+      io.stdout.add(output);
+    } else {
+      io.stderr.add(output);
+    }
+  }
 
   wasm.FunctionImportExportValue
   get _argsSizesGetImport => wasm.ImportExportKind.function((

--- a/lib/src/wasi/wasi.dart
+++ b/lib/src/wasi/wasi.dart
@@ -20,6 +20,12 @@ export 'version.dart';
 /// signal behavior. Returning normally reports success to the guest.
 typedef WASIProcRaiseHandler = void Function(WASIProcessSignal signal);
 
+/// Receives a byte chunk written by a WASI Preview1 stdout or stderr stream.
+///
+/// Output sinks run synchronously as part of `fd_write`. Each invocation
+/// receives bytes detached from the guest's linear memory.
+typedef WASIOutputSink = void Function(Uint8List bytes);
+
 /// WASI Preview1 process signal values.
 enum WASIProcessSignal {
   /// Reserved no-signal value.
@@ -144,6 +150,8 @@ abstract interface class WASI {
     int stdout = 1,
     int stderr = 2,
     Map<int, WASIPreview1Socket> sockets = const <int, WASIPreview1Socket>{},
+    WASIOutputSink? stdoutSink,
+    WASIOutputSink? stderrSink,
     WASIProcRaiseHandler? procRaiseHandler,
     WASIVersion version = WASIVersion.preview1,
   }) {
@@ -159,6 +167,8 @@ abstract interface class WASI {
       stdout: stdout,
       stderr: stderr,
       sockets: sockets,
+      stdoutSink: stdoutSink,
+      stderrSink: stderrSink,
       procRaiseHandler: procRaiseHandler,
       version: version,
     );

--- a/test/readme_snippets_test.dart
+++ b/test/readme_snippets_test.dart
@@ -125,12 +125,21 @@ void main() {
     });
 
     test('wasi snippet style start returns exit code', () async {
-      final wasi = WASI(args: const ['demo'], env: const {'FOO': 'bar'});
+      final stdout = BytesBuilder();
+      final stderr = BytesBuilder();
+      final wasi = WASI(
+        args: const ['demo'],
+        env: const {'FOO': 'bar'},
+        stdoutSink: stdout.add,
+        stderrSink: stderr.add,
+      );
       final runtime = await WebAssembly.instantiate(
         _wasiStartModuleBytes.buffer,
         wasi.imports,
       );
       expect(wasi.start(runtime.instance), 42);
+      expect(stdout.toBytes(), isEmpty);
+      expect(stderr.toBytes(), isEmpty);
     });
   });
 }

--- a/test/wasi_test.dart
+++ b/test/wasi_test.dart
@@ -1407,6 +1407,98 @@ void main() {
       });
 
       test(
+        'fd_write forwards isolated stdout and stderr byte snapshots',
+        () async {
+          final stdout = BytesBuilder(copy: false);
+          final stderr = BytesBuilder(copy: false);
+          final capturingWasi = WASI(
+            stdoutSink: stdout.add,
+            stderrSink: stderr.add,
+          );
+          final result = await WebAssembly.instantiate(
+            _wasiBytes.buffer,
+            capturingWasi.imports,
+          );
+          final capturingInstance = result.instance;
+          final memory =
+              (capturingInstance.exports['memory'] as MemoryImportExportValue)
+                  .ref;
+          capturingWasi.finalizeBindings(capturingInstance, memory: memory);
+          final fdWrite =
+              capturingWasi.imports['wasi_snapshot_preview1']!['fd_write']
+                  as FunctionImportExportValue;
+          final bytes = Uint8List.view(memory.buffer);
+          final data = ByteData.view(memory.buffer);
+          const iovPtr = 128;
+          const bufferPtr = 256;
+          const writtenPtr = 1024;
+
+          void write(int fd, List<int> output) {
+            bytes.setAll(bufferPtr, output);
+            data.setUint32(iovPtr, bufferPtr, Endian.little);
+            data.setUint32(iovPtr + 4, output.length, Endian.little);
+            expect(fdWrite.ref([fd, iovPtr, 1, writtenPtr]), 0);
+            expect(data.getUint32(writtenPtr, Endian.little), output.length);
+          }
+
+          write(1, <int>[0, 255, 1]);
+          bytes[bufferPtr] = 42;
+          write(2, <int>[2, 254, 3]);
+          write(1, const <int>[]);
+
+          expect(stdout.toBytes(), <int>[0, 255, 1]);
+          expect(stderr.toBytes(), <int>[2, 254, 3]);
+        },
+      );
+
+      test(
+        'fd_write keeps output sinks isolated between WASI instances',
+        () async {
+          final firstOutput = BytesBuilder(copy: false);
+          final secondOutput = BytesBuilder(copy: false);
+
+          Future<void> writeFrom(
+            WASI wasi,
+            BytesBuilder output,
+            List<int> text,
+          ) async {
+            final result = await WebAssembly.instantiate(
+              _wasiBytes.buffer,
+              wasi.imports,
+            );
+            final localInstance = result.instance;
+            final memory =
+                (localInstance.exports['memory'] as MemoryImportExportValue)
+                    .ref;
+            wasi.finalizeBindings(localInstance, memory: memory);
+            final fdWrite =
+                wasi.imports['wasi_snapshot_preview1']!['fd_write']
+                    as FunctionImportExportValue;
+            final bytes = Uint8List.view(memory.buffer);
+            final data = ByteData.view(memory.buffer);
+            const iovPtr = 128;
+            const bufferPtr = 256;
+            const writtenPtr = 1024;
+            bytes.setAll(bufferPtr, text);
+            data.setUint32(iovPtr, bufferPtr, Endian.little);
+            data.setUint32(iovPtr + 4, text.length, Endian.little);
+
+            expect(fdWrite.ref([1, iovPtr, 1, writtenPtr]), 0);
+            expect(data.getUint32(writtenPtr, Endian.little), text.length);
+            expect(output.toBytes(), text);
+          }
+
+          await writeFrom(WASI(stdoutSink: firstOutput.add), firstOutput, [1]);
+          await writeFrom(WASI(stdoutSink: secondOutput.add), secondOutput, [
+            2,
+          ]);
+
+          expect(firstOutput.toBytes(), <int>[1]);
+          expect(secondOutput.toBytes(), <int>[2]);
+        },
+      );
+
+      test(
         'fd_write writes JS stdout and stderr through Node process streams',
         () {
           final spy = installNodeStdioSpy();


### PR DESCRIPTION
Adds optional per-instance stdout and stderr byte sinks for WASI Preview1 fd_write output. Default host output behavior is unchanged when sinks are omitted. Includes native, browser, Node, and README coverage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional per-instance sinks for capturing WASI stdout and stderr output.
  * Captured output is delivered as byte data, supporting binary content and independent stream handling.
  * Existing console and native stream behavior remains available when sinks are not configured.

* **Documentation**
  * Added README guidance for capturing guest output with byte builders.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->